### PR TITLE
Add postman2pytest to Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ In January 2026, Postman acquired Fern to strengthen API documentation and SDK g
 - [openapi-to-postman](https://github.com/postmanlabs/openapi-to-postman) - Official tool to convert OpenAPI 3.x specs to Postman Collections.
 - [postman-to-openapi](https://github.com/joolfe/postman-to-openapi) - Convert Postman Collections to OpenAPI 3.0 spec.
 - [postman2openapi](https://github.com/kevinswiber/postman2openapi) - CLI and web tool to convert Postman 2.x collections to OpenAPI 3.0.
+- [postman2pytest](https://github.com/golikovichev/postman2pytest) - Convert Postman Collection v2.1 JSON into runnable pytest test suites in one command.
 - [specmatic](https://specmatic.io) - Contract testing tool that works with OpenAPI specs and Postman collections.
 
 ## Newman Reporters


### PR DESCRIPTION
Adds [postman2pytest](https://github.com/golikovichev/postman2pytest) under the existing Converters section.

## What it does

Converts Postman Collection v2.1 JSON files into runnable pytest test suites in one command. Sits alongside the existing converters in the section (postman2openapi, openapi-to-postman) but targets pytest as the output format instead of OpenAPI.

## Why it fits

- **Active**: v1.0.0 shipped to PyPI on 24.04.2026, MIT licensed
- **Tested**: 36 unit tests, CI matrix on Python 3.10 / 3.11 / 3.12
- **Documented**: README with quickstart, sample input and output, architecture notes
- **Useful**: bridges the documentation-test gap for Python teams that maintain a Postman collection alongside a pytest CI pipeline. Newman runs the collection but does not generate pytest code that integrates with existing fixtures, parametrisation, or assertions

## Entry placed alphabetically

Inserted between `postman2openapi` and `specmatic` to maintain the existing alphabetical ordering of the Converters section.

## Links

- Repo: https://github.com/golikovichev/postman2pytest
- PyPI: https://pypi.org/project/postman2pytest/
- Article (Dev.to): https://dev.to/golikovichev/postman-and-pytest-are-living-in-parallel-universes-heres-a-bridge-5bgn